### PR TITLE
Implement Var usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,12 @@ matrix:
       cargo +nightly-2017-10-09 fmt --all -- --write-mode=diff
 before_script:
 - |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
+  which cargo-coverage && which cargo-coveralls || cargo install --force cargo-travis &&
+  export PATH=$HOME/.cargo/bin:$PATH
 script:
 - |
-  travis-cargo build &&
-  travis-cargo clean &&
-  travis-cargo test &&
-  travis-cargo bench
+  cargo test -- --test-threads=1 &&
+  cargo bench
 notifications:
   email:
     on_success: never

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ use std::process::Command;
 fn main() {
     let env = Environment::inherit().insert("foo", "bar");
 
-
     let mut c = Command::new("printenv");
 
     let output = c.env_clear()
@@ -38,6 +37,33 @@ fn main() {
     assert!(output.contains("foo=bar"));
 
 }
+```
+
+Better example with `Var`:
+
+```rust
+extern crate environment;
+
+use std::process::Command;
+
+fn main() {
+    let foo: Var = ("FOO", "BAR").into();
+
+    let env = Environment::inherit()
+        .with_var(foo)
+        .var("FOO").is("BAR").append("BAZ");
+
+    let mut c = Command::new("printenv");
+
+    let output = c.env_clear()
+        .envs(env.compile())
+        .output()
+        .expect("failed to execute command");
+
+    let output = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.contains("FOO=BARBAZ"));
+
 ```
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,189 @@
 use std::ffi::OsString;
 use std::iter::FromIterator;
 
+/// Structure that represent a unique Variable.
+#[derive(Clone, Debug)]
+pub struct Var {
+    /// The variable's key.
+    key: OsString,
+    /// The variable's value.
+    value: OsString,
+    /// Conditional statement for this variable.
+    condition: bool,
+    /// The environment that own the variable.
+    environment: Environment,
+}
+
+impl Var {
+    /// Check if the Var's value is strictly different of the input.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate environment;
+    ///
+    /// let var: environment::Var = ("FOO", "BAR").into();
+    ///
+    /// assert_eq!(var.clone().isnt("BAR").assign("BAZ").var("FOO"), var);
+    /// ```
+    pub fn isnt<T: ToString>(mut self, value: T) -> Self {
+        self.condition = self.value != OsString::from(value.to_string());
+
+        self
+    }
+
+    /// Check if the Var's value is strictly equal to the input.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate environment;
+    ///
+    /// let var: environment::Var = ("FOO", "BAR").into();
+    ///
+    /// assert_eq!(var.clone().is("BAZ").assign("BAZ").var("FOO"), var);
+    /// ```
+    pub fn is<T: ToString>(mut self, value: T) -> Self {
+        self.condition = self.value == OsString::from(value.to_string());
+
+        self
+    }
+
+    /// Assign a new value to the variable.
+    ///
+    /// Note: assigning can be conditioned by
+    /// [is](struct.Var.html#method.is) or [isnt](struct.Var.html#method.isnt)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate environment;
+    ///
+    /// let var: environment::Var = ("FOO", "BAR").into();
+    ///
+    /// assert_eq!(var.clone().is("BAZ").assign("BAZ").var("FOO"), var);
+    ///
+    /// assert!(var.clone().isnt("BAZ").assign("BAZ").var("FOO") != var);
+    ///
+    /// ```
+    pub fn assign<T: ToString>(mut self, value: T) -> Environment {
+        if self.condition {
+            self.value = OsString::from(value.to_string());
+        }
+
+        self.environment.vars.push((self.key, self.value));
+
+        self.environment
+    }
+
+    /// Clear the value of a variable.
+    ///
+    /// Note: clearing can be conditioned by
+    /// [is](struct.Var.html#method.is) or [isnt](struct.Var.html#method.isnt)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate environment;
+    ///
+    /// let var: environment::Var = ("FOO", "BAR").into();
+    ///
+    /// assert_eq!(var.clone().is("BAR").clear().var("FOO"), ("FOO", "").into());
+    ///
+    /// assert_eq!(var.clone().isnt("BAR").clear().var("FOO"), var);
+    ///
+    /// ```
+    pub fn clear(mut self) -> Environment {
+        if self.condition {
+            self.value.clear();
+        }
+
+        self.environment.vars.push((self.key, self.value));
+
+        self.environment
+    }
+
+    /// Append a value to the current variable's value.
+    ///
+    /// Note: appending can be conditioned by
+    /// [is](struct.Var.html#method.is) or [isnt](struct.Var.html#method.isnt)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate environment;
+    ///
+    /// let var: environment::Var = ("FOO", "BAR").into();
+    ///
+    /// assert_eq!(var.clone().is("BAR").append("BAZ").var("FOO"), ("FOO", "BARBAZ").into());
+    ///
+    /// assert_eq!(var.clone().isnt("BAR").append("BAZ").var("FOO"), var);
+    ///
+    /// ```
+    pub fn append<T: ToString>(mut self, value: T) -> Environment {
+        if self.condition {
+            self.value.push(value.to_string());
+        }
+
+        self.environment.vars.push((self.key, self.value));
+
+        self.environment
+    }
+
+    /// Define the variable's value equal to the system variable.
+    ///
+    /// Note: inheriting can be conditioned by
+    /// [is](struct.Var.html#method.is) or [isnt](struct.Var.html#method.isnt)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate environment;
+    ///
+    /// ::std::env::set_var("FOO", "BAR");
+    ///
+    /// let var: environment::Var = ("FOO", "BAZ").into();
+    ///
+    /// assert_eq!(var.clone().is("BAZ").inherit().var("FOO"), ("FOO", "BAR").into());
+    /// assert_eq!(var.clone().isnt("BAZ").inherit().var("FOO"), ("FOO", "BAZ").into());
+    ///
+    /// ```
+    pub fn inherit(mut self) -> Environment {
+        if self.condition {
+            self.value = if let Some(v) = ::std::env::vars_os()
+                .filter(|&(ref k, _)| k == &self.key)
+                .collect::<Vec<(OsString, OsString)>>()
+                .first()
+            {
+                v.1.clone()
+            } else {
+                OsString::new()
+            };
+        }
+
+        self.environment.vars.push((self.key, self.value));
+
+        self.environment
+    }
+}
+
+impl<T: ToString, Z: ToString> From<(T, Z)> for Var {
+    fn from(v: (T, Z)) -> Self {
+        Self {
+            key: OsString::from(v.0.to_string()),
+            value: OsString::from(v.1.to_string()),
+            condition: true,
+            environment: Environment::empty(),
+        }
+    }
+}
+
+impl PartialEq for Var {
+    fn eq(&self, other: &Self) -> bool {
+        (&self.key, &self.value) == (&other.key, &other.value)
+    }
+}
+
 /// Structure to deal with environment variables
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Environment {
@@ -77,6 +260,45 @@ impl Environment {
             ::std::env::vars_os().chain(self.vars).collect()
         } else {
             self.vars
+        }
+    }
+
+    pub fn with_var<T: Into<Var>>(mut self, v: T) -> Environment {
+        let var = v.into();
+        self.vars.push((var.key, var.value));
+
+        self
+    }
+
+    pub fn var<T: ToString>(self, key: T) -> Var {
+        let key = OsString::from(key.to_string());
+
+        Var {
+            key: key.clone(),
+            value: if self.inherit {
+                if let Some(v) = ::std::env::vars_os()
+                    .chain(self.vars.clone())
+                    .filter(|&(ref k, _)| k == &key)
+                    .collect::<Vec<(OsString, OsString)>>()
+                    .last()
+                {
+                    v.1.clone()
+                } else {
+                    OsString::new()
+                }
+            } else if let Some(v) = self.vars
+                .clone()
+                .into_iter()
+                .filter(|&(ref k, _)| k == &key)
+                .collect::<Vec<(OsString, OsString)>>()
+                .last()
+            {
+                v.1.clone()
+            } else {
+                OsString::new()
+            },
+            condition: true,
+            environment: self,
         }
     }
 }
@@ -292,5 +514,189 @@ mod test {
             .collect();
 
         assert_eq!(env.compile(), expected);
+    }
+
+    #[test]
+    fn var_init() {
+        let v: Var = ("KEY", "VALUE").into();
+        let v2 = Var {
+            environment: Environment::empty(),
+            condition: true,
+            key: "KEY".into(),
+            value: "VALUE".into(),
+        };
+
+        assert_eq!(v, v2);
+    }
+
+    #[test]
+    fn environment_var() {
+        let v: Var = ("FOO", "BAR").into();
+
+        ::std::env::set_var("FOO", "BAR");
+
+        let e = Environment::inherit();
+        assert_eq!(v, e.var("FOO"));
+
+        ::std::env::remove_var("FOO");
+        assert!(::std::env::var_os("FOO") == None);
+    }
+
+    #[test]
+    fn environment_var_2() {
+        assert!(::std::env::var_os("FOO") == None);
+
+        let e_based = Environment::inherit().insert("FOO", "BAR");
+
+        let e = Environment::inherit();
+        assert_eq!(e_based, e.var("FOO").assign("BAR"));
+
+        ::std::env::remove_var("FOO");
+        assert!(::std::env::var_os("FOO") == None);
+    }
+
+    #[test]
+    fn environment_var_append() {
+        assert!(::std::env::var_os("FOO") == None);
+
+        let v: Var = ("FOO", "BARBAZ").into();
+
+        ::std::env::set_var("FOO", "BAR");
+
+        let e = Environment::inherit();
+        assert_eq!(v, e.var("FOO").append("BAZ").var("FOO"));
+
+        ::std::env::remove_var("FOO");
+        assert!(::std::env::var_os("FOO") == None);
+    }
+
+    #[test]
+    fn environment_var_clear() {
+        assert!(::std::env::var_os("FOO") == None);
+
+        let v: Var = ("FOO", "").into();
+
+        ::std::env::set_var("FOO", "BAR");
+
+        let e = Environment::inherit();
+        assert_eq!(v, e.var("FOO").clear().var("FOO"));
+
+        ::std::env::remove_var("FOO");
+        assert!(::std::env::var_os("FOO") == None);
+    }
+
+    #[test]
+    fn environment_var_replace_if() {
+        assert!(::std::env::var_os("FOO") == None);
+
+        ::std::env::set_var("FOO", "BAR");
+
+        let e = Environment::inherit();
+
+        assert_eq!(
+            e.clone().var("FOO").is("BAR").assign("BAZ").var("FOO"),
+            ("FOO", "BAZ").into()
+        );
+
+        assert_eq!(
+            e.clone().var("FOO").isnt("BAZ").assign("BAZ").var("FOO"),
+            ("FOO", "BAZ").into()
+        );
+
+        assert_eq!(
+            e.var("FOO").isnt("BAR").assign("BAZ").var("FOO"),
+            ("FOO", "BAR").into()
+        );
+
+        ::std::env::remove_var("FOO");
+        assert!(::std::env::var_os("FOO") == None);
+    }
+
+    #[test]
+    fn environment_var_clear_if() {
+        assert!(::std::env::var_os("FOO") == None);
+
+        ::std::env::set_var("FOO", "BAR");
+
+        let e = Environment::inherit();
+
+        assert_eq!(
+            e.clone().var("FOO").is("BAR").clear().var("FOO"),
+            ("FOO", "").into()
+        );
+
+        assert_eq!(
+            e.var("FOO").isnt("BAR").clear().var("FOO"),
+            ("FOO", "BAR").into()
+        );
+
+        ::std::env::remove_var("FOO");
+        assert!(::std::env::var_os("FOO") == None);
+    }
+
+    #[test]
+    fn environment_var_append_if() {
+        assert!(::std::env::var_os("FOO") == None);
+
+        ::std::env::set_var("FOO", "BAR");
+
+        let e = Environment::inherit();
+
+        assert_eq!(
+            e.clone().var("FOO").is("BAR").append("BAZ").var("FOO"),
+            ("FOO", "BARBAZ").into()
+        );
+
+        assert_eq!(
+            e.var("FOO").isnt("BAR").append("BAZ").var("FOO"),
+            ("FOO", "BAR").into()
+        );
+
+        ::std::env::remove_var("FOO");
+        assert!(::std::env::var_os("FOO") == None);
+    }
+
+    #[test]
+    fn complete_environment() {
+        let env = Environment::inherit()
+            .var("FOO").assign("BAR") // Assign a value to FOO (i.e. : FOO=BAR)
+            .var("FOO").append("BAZ") // Append a value to FOO (i.e. : FOO=BARBAZ)
+            .var("FOO").clear() // Clear the value of FOO (i.e. : FOO="")
+            .var("FOO").assign("BAR")
+            .var("FOO").is("BAR").clear() // Clear the value if FOO is BAR (i.e. : FOO="")
+            .var("FOO").assign("BAZ")
+            .var("FOO").isnt("BAR").clear() // Clear the value if FOO isnt BAR (i.e. : FOO="")
+            .var("FOO").isnt("BAR").append("BAZ"); // Append a value to FOO (i.e : FOO=BAZ)
+
+        assert_eq!(env.var("FOO"), ("FOO", "BAZ").into());
+    }
+
+    #[test]
+    fn use_var() {
+        let v: Var = ("FOO", "BAR").into();
+
+        Environment::empty().with_var(v);
+    }
+
+    #[test]
+    fn readme_example() {
+        let foo: Var = ("FOO", "BAR").into();
+
+        let env = Environment::inherit()
+            .with_var(foo)
+            .var("FOO")
+            .is("BAR")
+            .append("BAZ");
+
+        let mut c = Command::new("printenv");
+
+        let output = c.env_clear()
+            .envs(env.compile())
+            .output()
+            .expect("failed to execute command");
+
+        let output = String::from_utf8_lossy(&output.stdout);
+
+        assert!(output.contains("FOO=BARBAZ"));
     }
 }


### PR DESCRIPTION
Add some helpers to deal with variables:

```rust
let env = Environment::inherit()
    .var("FOO").assign("BAR") // Assign a value to FOO (i.e. : FOO=BAR)
    .var("PATH").append(";path") // Append a value to PATH (i.e. : PATH=/usr/bin;path)
    .var("FOO").clear() // Clear the value of FOO (i.e. : FOO="")
    .var("FOO").assign("BAR")
    .var("FOO").is("BAR").clear() // Clear the value if FOO is BAR (i.e. : FOO="")
    .var("FOO").assign("BAZ")
    .var("FOO").isnt("BAR").clear() // Clear the value if FOO isnt BAR (i.e. : FOO="")
    .var("FOO").isnt("BAR").append("BAZ"); // Append a value to FOO (i.e : FOO=BAZ)

```
Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>